### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/CMSForNerd/CmsForNerd/security/code-scanning/1](https://github.com/CMSForNerd/CmsForNerd/security/code-scanning/1)

In general, the fix is to explicitly declare a `permissions` block that grants only the scopes needed by this workflow/job. Since this workflow just checks out code and runs a SonarCloud scan that uses `GITHUB_TOKEN` to read PR information, it only needs read access to repository contents; it doesn’t need to write to the repo or modify other resources. The safest minimal fix is to set `contents: read`.

The single best way to fix this without changing existing functionality is to add a `permissions` section at the workflow root level (so it applies to all jobs) directly under `name: Build` (or under `on:` if you prefer), with `contents: read`. No other changes are required. Concretely, in `.github/workflows/build.yml`, between lines 1 and 2, add:

```yaml
permissions:
  contents: read
```

This does not require any imports or additional methods, as this is a YAML configuration for GitHub Actions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
