### PR TITLE
Fix misspelled /opt/cmdfornerd directory reference

### DIFF
--- a/docs/ANSIBLE-PODMAN-COMPOSE-DEPLOYMENT.md
+++ b/docs/ANSIBLE-PODMAN-COMPOSE-DEPLOYMENT.md
@@ -58,7 +58,6 @@ All files and logs are written directly to host directories to ensure high avail
 | `/opt/cmsfornerd/nginx` | `/etc/nginx/conf.d` | Custom, read-only Nginx routing and block rules |
 | `/opt/cmsfornerd/php-fpm` | `/usr/local/etc/php-fpm.d` | Hardened PHP-FPM pool configuration |
 | `/opt/cmsfornerd/codes` | `/var/www/html` | Main CmsForNerd codebase (writable by PHP, read-only by Nginx)|
-| `/opt/cmdfornerd` | Symlink to `/opt/cmsfornerd` | Provides multi-path compatibility for secondary validation engines |
 
 ---
 

--- a/playbooks/roles/podman_prod/tasks/main.yml
+++ b/playbooks/roles/podman_prod/tasks/main.yml
@@ -95,13 +95,6 @@
     - "{{ php_fpm_path }}"
     - "{{ codes_path }}"
 
-- name: Create compatible symlink /opt/cmdfornerd to /opt/cmsfornerd
-  ansible.builtin.file:
-    src: "{{ project_path }}"
-    dest: /opt/cmdfornerd
-    state: link
-    force: true
-
 # Clone or Copy codebase (Storage Sovereignty)
 - name: Clone CmsForNerd Official Repository into codes path
   ansible.builtin.git:


### PR DESCRIPTION
Removed references to the misspelled directory /opt/cmdfornerd from deployment playbooks and guides.

---
*PR created automatically by Jules for task [11423649836747084478](https://jules.google.com/task/11423649836747084478) started by @linuxmalaysia*