### PR TITLE
Secure feed sitemaps and graduation certificate against XSS

### DIFF
--- a/contents/graduation-body.inc
+++ b/contents/graduation-body.inc
@@ -19,7 +19,7 @@
                         <div class="cert-award">
                             <p>This certifies that</p>
                             <div class="student-name">
-                                <?= htmlspecialchars($_GET['student'] ?? '[Your Name Here]') ?>
+                                <?= htmlspecialchars((string) ($_GET['student'] ?? '[Your Name Here]'), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?>
                             </div>
                         </div>
 
@@ -58,7 +58,7 @@
 
                         <div class="footer-meta">
                             <p>Verification Date: <?= date('F j, Y') ?></p>
-                            <p class="digital-sig">SHA-256 ID: <?= hash('sha256', ($_GET['student'] ?? 'anon') . date('Y-m-d')) ?></p>
+                            <p class="digital-sig">SHA-256 ID: <?= htmlspecialchars(hash('sha256', (string) ($_GET['student'] ?? 'anon') . date('Y-m-d')), ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8') ?></p>
                         </div>
                     </div>
                 </div>

--- a/includes/SecurityUtils.php
+++ b/includes/SecurityUtils.php
@@ -68,6 +68,50 @@ final class SecurityUtils
     }
 
     /**
+     * [SECURITY] Scan contents directory and discover valid paired pages.
+     * Centralized to prevent SonarCloud Code Duplication.
+     *
+     * @param string $fragmentDir Absolute path to contents directory.
+     * @param string $rootDir Absolute path to project root directory.
+     * @return array<int, array{slug: string, title: string, mtime: int, filemtime: int}>
+     */
+    public static function discoverPages(string $fragmentDir, string $rootDir): array
+    {
+        $pages = [];
+
+        if (is_dir($fragmentDir)) {
+            $rawFragments = glob($fragmentDir . '*-body.inc');
+            $fragments = is_array($rawFragments) ? $rawFragments : [];
+
+            foreach ($fragments as $file) {
+                $slug = str_replace('-body.inc', '', basename($file));
+
+                // Exclusion list
+                $exclude = ['index', 'sitemap', 'empty', '403', '404', 'header', 'footer'];
+                if (in_array($slug, $exclude, true)) {
+                    continue;
+                }
+
+                $masterFile = $rootDir . '/' . $slug . '.php';
+
+                if (file_exists($masterFile)) {
+                    $mTime = max(filemtime($masterFile), filemtime($file));
+                    $title = ucfirst(str_replace('-', ' ', $slug));
+
+                    $pages[] = [
+                        'slug'      => $slug,
+                        'title'     => $title,
+                        'mtime'     => (int) $mTime,
+                        'filemtime' => (int) filemtime($file),
+                    ];
+                }
+            }
+        }
+
+        return $pages;
+    }
+
+    /**
      * [SECURITY] Generate a Content Security Policy (CSP) Nonce.
      * MUST be used for inline scripts to comply with v3.3+ safety protocols.
      * * @return string A base64 encoded random 16-byte string.

--- a/includes/SecurityUtils.php
+++ b/includes/SecurityUtils.php
@@ -52,6 +52,22 @@ final class SecurityUtils
     }
 
     /**
+     * [SECURITY] Get safe sanitized base URL to prevent Host Header injection / XSS.
+     * @return string The safe Base URL with a trailing slash.
+     */
+    public static function getSafeBaseUrl(): string
+    {
+        $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
+        $host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+        $host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
+
+        $scriptPath = $_SERVER['SCRIPT_NAME'] ?? '';
+        $dirPath  = str_replace('\\', '/', dirname($scriptPath));
+
+        return rtrim($protocol . $host . $dirPath, '/') . '/';
+    }
+
+    /**
      * [SECURITY] Generate a Content Security Policy (CSP) Nonce.
      * MUST be used for inline scripts to comply with v3.3+ safety protocols.
      * * @return string A base64 encoded random 16-byte string.

--- a/ror.php
+++ b/ror.php
@@ -34,33 +34,19 @@ echo '    <title>ROR Sitemap for CMSForNerd Laboratory v3.5</title>' . PHP_EOL;
 echo '    <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . 'index.php') . '</link>' . PHP_EOL;
 
 // 5. [ITEM SCAN]
-$fragmentDir = __DIR__ . '/contents/';
+$pages = \CmsForNerd\SecurityUtils::discoverPages(__DIR__ . '/contents/', __DIR__);
 
-if (is_dir($fragmentDir)) {
-    $rawFragments = glob($fragmentDir . '*-body.inc');
-    $fragments = is_array($rawFragments) ? $rawFragments : [];
+foreach ($pages as $page) {
+    $slug    = $page['slug'];
+    $title   = $page['title'];
+    $updated = date('Y-m-d', $page['filemtime']);
 
-    foreach ($fragments as $file) {
-        $slug = str_replace('-body.inc', '', basename($file));
-        
-        $exclude = ['index', 'sitemap', 'empty', '403', '404', 'header', 'footer'];
-        if (in_array($slug, $exclude, true)) {
-            continue;
-        }
-
-        $masterFile = __DIR__ . '/' . $slug . '.php';
-
-        if (file_exists($masterFile)) {
-            $title = ucfirst(str_replace('-', ' ', $slug));
-
-            echo '    <item>' . PHP_EOL;
-            echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . '</link>' . PHP_EOL;
-            echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
-            echo '      <ror:type>resource</ror:type>' . PHP_EOL;
-            echo '      <ror:updated>' . date('Y-m-d', (int) filemtime($file)) . '</ror:updated>' . PHP_EOL;
-            echo '    </item>' . PHP_EOL;
-        }
-    }
+    echo '    <item>' . PHP_EOL;
+    echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . '</link>' . PHP_EOL;
+    echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
+    echo '      <ror:type>resource</ror:type>' . PHP_EOL;
+    echo '      <ror:updated>' . $updated . '</ror:updated>' . PHP_EOL;
+    echo '    </item>' . PHP_EOL;
 }
 
 echo '  </channel>' . PHP_EOL;

--- a/ror.php
+++ b/ror.php
@@ -22,8 +22,13 @@ while (ob_get_level()) {
 // 2. [EDUCATION] Auto-URL Detection
 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
 $host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+// Sanitize host to prevent HTTP Host Header attacks / injection
+$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
 $dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
 $baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
+
+// Helper function to escape XML output
+$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
 // 3. [SECURITY] Hardened Headers
 header("Content-Type: application/xml; charset=utf-8");
@@ -33,13 +38,14 @@ header("X-Content-Type-Options: nosniff");
 echo '<rss version="2.0" xmlns:ror="http://www.rorweb.com/0.1/">' . PHP_EOL;
 echo '  <channel>' . PHP_EOL;
 echo '    <title>ROR Sitemap for CMSForNerd Laboratory v3.5</title>' . PHP_EOL;
-echo '    <link>' . $baseUrl . 'index.php</link>' . PHP_EOL;
+echo '    <link>' . $esc($baseUrl . 'index.php') . '</link>' . PHP_EOL;
 
 // 5. [ITEM SCAN]
 $fragmentDir = __DIR__ . '/contents/';
 
 if (is_dir($fragmentDir)) {
-    $fragments = glob($fragmentDir . '*-body.inc');
+    $rawFragments = glob($fragmentDir . '*-body.inc');
+    $fragments = is_array($rawFragments) ? $rawFragments : [];
 
     foreach ($fragments as $file) {
         $slug = str_replace('-body.inc', '', basename($file));
@@ -55,10 +61,10 @@ if (is_dir($fragmentDir)) {
             $title = ucfirst(str_replace('-', ' ', $slug));
 
             echo '    <item>' . PHP_EOL;
-            echo '      <link>' . $baseUrl . $slug . '.php</link>' . PHP_EOL;
-            echo '      <title>' . $title . '</title>' . PHP_EOL;
+            echo '      <link>' . $esc($baseUrl . $slug . '.php') . '</link>' . PHP_EOL;
+            echo '      <title>' . $esc($title) . '</title>' . PHP_EOL;
             echo '      <ror:type>resource</ror:type>' . PHP_EOL;
-            echo '      <ror:updated>' . date('Y-m-d', filemtime($file)) . '</ror:updated>' . PHP_EOL;
+            echo '      <ror:updated>' . date('Y-m-d', (int) filemtime($file)) . '</ror:updated>' . PHP_EOL;
             echo '    </item>' . PHP_EOL;
         }
     }

--- a/ror.php
+++ b/ror.php
@@ -20,15 +20,8 @@ while (ob_get_level()) {
 }
 
 // 2. [EDUCATION] Auto-URL Detection
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
-$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
-// Sanitize host to prevent HTTP Host Header attacks / injection
-$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
-$dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
-$baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
-
-// Helper function to escape XML output
-$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+require_once __DIR__ . '/vendor/autoload.php';
+$baseUrl = \CmsForNerd\SecurityUtils::getSafeBaseUrl();
 
 // 3. [SECURITY] Hardened Headers
 header("Content-Type: application/xml; charset=utf-8");
@@ -38,7 +31,7 @@ header("X-Content-Type-Options: nosniff");
 echo '<rss version="2.0" xmlns:ror="http://www.rorweb.com/0.1/">' . PHP_EOL;
 echo '  <channel>' . PHP_EOL;
 echo '    <title>ROR Sitemap for CMSForNerd Laboratory v3.5</title>' . PHP_EOL;
-echo '    <link>' . $esc($baseUrl . 'index.php') . '</link>' . PHP_EOL;
+echo '    <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . 'index.php') . '</link>' . PHP_EOL;
 
 // 5. [ITEM SCAN]
 $fragmentDir = __DIR__ . '/contents/';
@@ -61,8 +54,8 @@ if (is_dir($fragmentDir)) {
             $title = ucfirst(str_replace('-', ' ', $slug));
 
             echo '    <item>' . PHP_EOL;
-            echo '      <link>' . $esc($baseUrl . $slug . '.php') . '</link>' . PHP_EOL;
-            echo '      <title>' . $esc($title) . '</title>' . PHP_EOL;
+            echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . '</link>' . PHP_EOL;
+            echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
             echo '      <ror:type>resource</ror:type>' . PHP_EOL;
             echo '      <ror:updated>' . date('Y-m-d', (int) filemtime($file)) . '</ror:updated>' . PHP_EOL;
             echo '    </item>' . PHP_EOL;

--- a/rss.php
+++ b/rss.php
@@ -18,8 +18,13 @@ while (ob_get_level()) {
 // 2. [EDUCATION] Auto-URL Detection
 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
 $host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+// Sanitize host to prevent HTTP Host Header attacks / injection
+$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
 $dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
 $baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
+
+// Helper function to escape XML output
+$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
 // 3. [SECURITY] Hardened Headers
 header("Content-Type: application/rss+xml; charset=utf-8");
@@ -31,17 +36,18 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . PHP_EOL;
 echo '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">' . PHP_EOL;
 echo '  <channel>' . PHP_EOL;
 echo '    <title>CMSForNerd Laboratory v3.5</title>' . PHP_EOL;
-echo '    <link>' . $baseUrl . 'index.php</link>' . PHP_EOL;
+echo '    <link>' . $esc($baseUrl) . 'index.php</link>' . PHP_EOL;
 echo '    <description>Modern PHP 8.4+ educational CMS environment.</description>' . PHP_EOL;
 echo '    <language>en-us</language>' . PHP_EOL;
 echo '    <lastBuildDate>' . date(DATE_RSS) . '</lastBuildDate>' . PHP_EOL;
-echo '    <atom:link href="' . $baseUrl . 'rss.php" rel="self" type="application/rss+xml" />' . PHP_EOL;
+echo '    <atom:link href="' . $esc($baseUrl) . 'rss.php" rel="self" type="application/rss+xml" />' . PHP_EOL;
 
 // 5. [AUTOMATION] The Scanning Engine (Pair Logic)
 $fragmentDir = __DIR__ . '/contents/';
 
 if (is_dir($fragmentDir)) {
-    $fragments = glob($fragmentDir . '*-body.inc');
+    $rawFragments = glob($fragmentDir . '*-body.inc');
+    $fragments = is_array($rawFragments) ? $rawFragments : [];
 
     foreach ($fragments as $file) {
         $slug = str_replace('-body.inc', '', basename($file));
@@ -56,14 +62,14 @@ if (is_dir($fragmentDir)) {
 
         if (file_exists($masterFile)) {
             $mTime = max(filemtime($masterFile), filemtime($file));
-            $pubDate = date(DATE_RSS, $mTime);
+            $pubDate = date(DATE_RSS, (int) $mTime);
             $title = ucfirst(str_replace('-', ' ', $slug));
 
             echo '    <item>' . PHP_EOL;
-            echo '      <title>' . $title . '</title>' . PHP_EOL;
-            echo '      <link>' . $baseUrl . $slug . '.php</link>' . PHP_EOL;
-            echo '      <description>Updates for the ' . $title . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
-            echo '      <guid isPermaLink="true">' . $baseUrl . $slug . '.php</guid>' . PHP_EOL;
+            echo '      <title>' . $esc($title) . '</title>' . PHP_EOL;
+            echo '      <link>' . $esc($baseUrl . $slug) . '.php</link>' . PHP_EOL;
+            echo '      <description>Updates for the ' . $esc($title) . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
+            echo '      <guid isPermaLink="true">' . $esc($baseUrl . $slug) . '.php</guid>' . PHP_EOL;
             echo '      <pubDate>' . $pubDate . '</pubDate>' . PHP_EOL;
             echo '    </item>' . PHP_EOL;
         }

--- a/rss.php
+++ b/rss.php
@@ -36,37 +36,20 @@ echo '    <lastBuildDate>' . date(DATE_RSS) . '</lastBuildDate>' . PHP_EOL;
 echo '    <atom:link href="' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl) . 'rss.php" rel="self" type="application/rss+xml" />' . PHP_EOL;
 
 // 5. [AUTOMATION] The Scanning Engine (Pair Logic)
-$fragmentDir = __DIR__ . '/contents/';
+$pages = \CmsForNerd\SecurityUtils::discoverPages(__DIR__ . '/contents/', __DIR__);
 
-if (is_dir($fragmentDir)) {
-    $rawFragments = glob($fragmentDir . '*-body.inc');
-    $fragments = is_array($rawFragments) ? $rawFragments : [];
+foreach ($pages as $page) {
+    $slug    = $page['slug'];
+    $title   = $page['title'];
+    $pubDate = date(DATE_RSS, $page['mtime']);
 
-    foreach ($fragments as $file) {
-        $slug = str_replace('-body.inc', '', basename($file));
-        
-        // Exclusion list (Rules compliance)
-        $exclude = ['index', 'sitemap', 'empty', '403', '404', 'header', 'footer'];
-        if (in_array($slug, $exclude, true)) {
-            continue;
-        }
-
-        $masterFile = __DIR__ . '/' . $slug . '.php';
-
-        if (file_exists($masterFile)) {
-            $mTime = max(filemtime($masterFile), filemtime($file));
-            $pubDate = date(DATE_RSS, (int) $mTime);
-            $title = ucfirst(str_replace('-', ' ', $slug));
-
-            echo '    <item>' . PHP_EOL;
-            echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
-            echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</link>' . PHP_EOL;
-            echo '      <description>Updates for the ' . \CmsForNerd\SecurityUtils::escapeHtml($title) . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
-            echo '      <guid isPermaLink="true">' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</guid>' . PHP_EOL;
-            echo '      <pubDate>' . $pubDate . '</pubDate>' . PHP_EOL;
-            echo '    </item>' . PHP_EOL;
-        }
-    }
+    echo '    <item>' . PHP_EOL;
+    echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
+    echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</link>' . PHP_EOL;
+    echo '      <description>Updates for the ' . \CmsForNerd\SecurityUtils::escapeHtml($title) . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
+    echo '      <guid isPermaLink="true">' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</guid>' . PHP_EOL;
+    echo '      <pubDate>' . $pubDate . '</pubDate>' . PHP_EOL;
+    echo '    </item>' . PHP_EOL;
 }
 
 echo '  </channel>' . PHP_EOL;

--- a/rss.php
+++ b/rss.php
@@ -16,15 +16,8 @@ while (ob_get_level()) {
 }
 
 // 2. [EDUCATION] Auto-URL Detection
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
-$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
-// Sanitize host to prevent HTTP Host Header attacks / injection
-$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
-$dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
-$baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
-
-// Helper function to escape XML output
-$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+require_once __DIR__ . '/vendor/autoload.php';
+$baseUrl = \CmsForNerd\SecurityUtils::getSafeBaseUrl();
 
 // 3. [SECURITY] Hardened Headers
 header("Content-Type: application/rss+xml; charset=utf-8");
@@ -36,11 +29,11 @@ echo '<?xml version="1.0" encoding="UTF-8" ?>' . PHP_EOL;
 echo '<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">' . PHP_EOL;
 echo '  <channel>' . PHP_EOL;
 echo '    <title>CMSForNerd Laboratory v3.5</title>' . PHP_EOL;
-echo '    <link>' . $esc($baseUrl) . 'index.php</link>' . PHP_EOL;
+echo '    <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl) . 'index.php</link>' . PHP_EOL;
 echo '    <description>Modern PHP 8.4+ educational CMS environment.</description>' . PHP_EOL;
 echo '    <language>en-us</language>' . PHP_EOL;
 echo '    <lastBuildDate>' . date(DATE_RSS) . '</lastBuildDate>' . PHP_EOL;
-echo '    <atom:link href="' . $esc($baseUrl) . 'rss.php" rel="self" type="application/rss+xml" />' . PHP_EOL;
+echo '    <atom:link href="' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl) . 'rss.php" rel="self" type="application/rss+xml" />' . PHP_EOL;
 
 // 5. [AUTOMATION] The Scanning Engine (Pair Logic)
 $fragmentDir = __DIR__ . '/contents/';
@@ -66,10 +59,10 @@ if (is_dir($fragmentDir)) {
             $title = ucfirst(str_replace('-', ' ', $slug));
 
             echo '    <item>' . PHP_EOL;
-            echo '      <title>' . $esc($title) . '</title>' . PHP_EOL;
-            echo '      <link>' . $esc($baseUrl . $slug) . '.php</link>' . PHP_EOL;
-            echo '      <description>Updates for the ' . $esc($title) . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
-            echo '      <guid isPermaLink="true">' . $esc($baseUrl . $slug) . '.php</guid>' . PHP_EOL;
+            echo '      <title>' . \CmsForNerd\SecurityUtils::escapeHtml($title) . '</title>' . PHP_EOL;
+            echo '      <link>' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</link>' . PHP_EOL;
+            echo '      <description>Updates for the ' . \CmsForNerd\SecurityUtils::escapeHtml($title) . ' module in the v3.5 Laboratory.</description>' . PHP_EOL;
+            echo '      <guid isPermaLink="true">' . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug) . '.php</guid>' . PHP_EOL;
             echo '      <pubDate>' . $pubDate . '</pubDate>' . PHP_EOL;
             echo '    </item>' . PHP_EOL;
         }

--- a/sitemap.php
+++ b/sitemap.php
@@ -71,51 +71,17 @@ echo "  </url>" . PHP_EOL;
  * 6. [AUTOMATION] THE SCANNING ENGINE
  * Scans the laboratory contents directory for valid page pairs.
  */
-$fragmentDir = __DIR__ . '/contents/';
+$pages = \CmsForNerd\SecurityUtils::discoverPages(__DIR__ . '/contents/', __DIR__);
 
-if (is_dir($fragmentDir)) {
-    // Look for all Slave Fragments
-    $rawFragments = glob($fragmentDir . '*-body.inc');
-    $fragments = is_array($rawFragments) ? $rawFragments : [];
+foreach ($pages as $page) {
+    $slug    = $page['slug'];
+    $isoDate = date("c", $page['mtime']);
 
-    foreach ($fragments as $file) {
-        /**
-         * [EDUCATION] SLUG EXTRACTION
-         * Extracting the page name (e.g., 'about') from 'about-body.inc'.
-         */
-        $slug = str_replace('-body.inc', '', basename($file));
-
-        /**
-         * [SECURITY] RULE #8 COMPLIANCE
-         * Prevent sensitive system files or error pages from being indexed.
-         */
-        $exclude = ['index', 'sitemap', 'empty', '403', '404', 'header', 'footer'];
-        if (in_array($slug, $exclude, true)) {
-            continue;
-        }
-
-        /**
-         * [SECURITY] PAIR LOGIC VERIFICATION
-         * Only index the page if the Master Controller (.php) exists in the root.
-         */
-        $masterFile = __DIR__ . '/' . $slug . '.php';
-
-        if (file_exists($masterFile)) {
-            /**
-             * [LAB] DATE SYNCHRONIZATION
-             * We find the NEWEST modification date between the logic (.php)
-             * and the content (-body.inc) for SEO accuracy.
-             */
-            $mTime = max(filemtime($masterFile), filemtime($file));
-            $isoDate = date("c", (int) $mTime); // ISO 8601 format
-
-            echo "  <url>" . PHP_EOL;
-            echo "    <loc>" . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . "</loc>" . PHP_EOL;
-            echo "    <lastmod>{$isoDate}</lastmod>" . PHP_EOL;
-            echo "    <priority>0.8</priority>" . PHP_EOL;
-            echo "  </url>" . PHP_EOL;
-        }
-    }
+    echo "  <url>" . PHP_EOL;
+    echo "    <loc>" . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . "</loc>" . PHP_EOL;
+    echo "    <lastmod>{$isoDate}</lastmod>" . PHP_EOL;
+    echo "    <priority>0.8</priority>" . PHP_EOL;
+    echo "  </url>" . PHP_EOL;
 }
 
 // 7. [XML END]

--- a/sitemap.php
+++ b/sitemap.php
@@ -28,8 +28,13 @@ while (ob_get_level()) {
  */
 $protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
 $host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
+// Sanitize host to prevent HTTP Host Header attacks / injection
+$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
 $dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
 $baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
+
+// Helper function to escape XML output
+$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
 
 /**
  * 3. [SECURITY] HARDENED HEADERS
@@ -65,7 +70,7 @@ echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . PHP_EOL;
  * The root index.php is the first 'specimen' to be indexed.
  */
 echo "  <url>" . PHP_EOL;
-echo "    <loc>{$baseUrl}index.php</loc>" . PHP_EOL;
+echo "    <loc>" . $esc($baseUrl . 'index.php') . "</loc>" . PHP_EOL;
 echo "    <priority>1.0</priority>" . PHP_EOL;
 echo "  </url>" . PHP_EOL;
 
@@ -77,7 +82,8 @@ $fragmentDir = __DIR__ . '/contents/';
 
 if (is_dir($fragmentDir)) {
     // Look for all Slave Fragments
-    $fragments = glob($fragmentDir . '*-body.inc');
+    $rawFragments = glob($fragmentDir . '*-body.inc');
+    $fragments = is_array($rawFragments) ? $rawFragments : [];
 
     foreach ($fragments as $file) {
         /**
@@ -108,10 +114,10 @@ if (is_dir($fragmentDir)) {
              * and the content (-body.inc) for SEO accuracy.
              */
             $mTime = max(filemtime($masterFile), filemtime($file));
-            $isoDate = date("c", $mTime); // ISO 8601 format
+            $isoDate = date("c", (int) $mTime); // ISO 8601 format
 
             echo "  <url>" . PHP_EOL;
-            echo "    <loc>{$baseUrl}{$slug}.php</loc>" . PHP_EOL;
+            echo "    <loc>" . $esc($baseUrl . $slug . '.php') . "</loc>" . PHP_EOL;
             echo "    <lastmod>{$isoDate}</lastmod>" . PHP_EOL;
             echo "    <priority>0.8</priority>" . PHP_EOL;
             echo "  </url>" . PHP_EOL;

--- a/sitemap.php
+++ b/sitemap.php
@@ -26,15 +26,8 @@ while (ob_get_level()) {
  * Manually calculates the Base URL to ensure compatibility across
  * localhost, development domains (.test), and production servers.
  */
-$protocol = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? "https://" : "http://";
-$host     = $_SERVER['HTTP_HOST'] ?? 'localhost';
-// Sanitize host to prevent HTTP Host Header attacks / injection
-$host     = preg_replace('/[^a-zA-Z0-9\-.:]/', '', $host);
-$dirPath  = str_replace('\\', '/', dirname($_SERVER['SCRIPT_NAME']));
-$baseUrl  = rtrim($protocol . $host . $dirPath, '/') . '/';
-
-// Helper function to escape XML output
-$esc = fn(string $val): string => htmlspecialchars($val, ENT_XML1 | ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+require_once __DIR__ . '/vendor/autoload.php';
+$baseUrl = \CmsForNerd\SecurityUtils::getSafeBaseUrl();
 
 /**
  * 3. [SECURITY] HARDENED HEADERS
@@ -70,7 +63,7 @@ echo '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">' . PHP_EOL;
  * The root index.php is the first 'specimen' to be indexed.
  */
 echo "  <url>" . PHP_EOL;
-echo "    <loc>" . $esc($baseUrl . 'index.php') . "</loc>" . PHP_EOL;
+echo "    <loc>" . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . 'index.php') . "</loc>" . PHP_EOL;
 echo "    <priority>1.0</priority>" . PHP_EOL;
 echo "  </url>" . PHP_EOL;
 
@@ -117,7 +110,7 @@ if (is_dir($fragmentDir)) {
             $isoDate = date("c", (int) $mTime); // ISO 8601 format
 
             echo "  <url>" . PHP_EOL;
-            echo "    <loc>" . $esc($baseUrl . $slug . '.php') . "</loc>" . PHP_EOL;
+            echo "    <loc>" . \CmsForNerd\SecurityUtils::escapeHtml($baseUrl . $slug . '.php') . "</loc>" . PHP_EOL;
             echo "    <lastmod>{$isoDate}</lastmod>" . PHP_EOL;
             echo "    <priority>0.8</priority>" . PHP_EOL;
             echo "  </url>" . PHP_EOL;


### PR DESCRIPTION
This pull request fixes five Cross-Site Scripting (XSS) and header/parameter injection security vulnerabilities identified by Snyk Code. Specifically, it sanitizes the host header input and escapes output parameters in `rss.php`, `sitemap.php`, `ror.php`, and `contents/graduation-body.inc` using XML/HTML secure escape flags, ensuring robust defensive engineering across the CMS feeds and laboratory templates.

---
*PR created automatically by Jules for task [6182171114248019682](https://jules.google.com/task/6182171114248019682) started by @linuxmalaysia*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved escaping of student names, digital signatures, URLs, titles, and other generated output to help prevent unsafe content from being rendered.

* **Bug Fixes**
  * RSS feeds and sitemaps now generate safer, more consistent links and metadata.
  * Page listings use reliable timestamps and include only valid published pages.

* **Improvements**
  * RSS feeds and sitemaps now discover available pages more consistently, reducing duplication and missed entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->